### PR TITLE
Make it possible to use a FormatLogger with DatetimeRotatingLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ julia> filter(f -> endswith(f, ".log"), readdir(pwd()))
 ```
 
 The user implicitly controls when the files will be rolled over based on the `DateFormat` given.
+To control the logging output it is possible to pass a formatter function as the first argument
+in the constructor. See `FormatLogger` for the requirements on the formatter function.
 
 ## `FormatLogger` (*Sink*)
 The `FormatLogger` is a sink that formats the message and prints to a wrapped IO.

--- a/src/LoggingExtras.jl
+++ b/src/LoggingExtras.jl
@@ -38,8 +38,8 @@ include("activefiltered.jl")
 include("earlyfiltered.jl")
 include("minlevelfiltered.jl")
 include("filelogger.jl")
-include("datetime_rotation.jl")
 include("formatlogger.jl")
+include("datetime_rotation.jl")
 include("deprecated.jl")
 
 end # module

--- a/src/formatlogger.jl
+++ b/src/formatlogger.jl
@@ -1,7 +1,7 @@
 
 struct FormatLogger <: AbstractLogger
     f::Function
-    io::IO
+    stream::IO
     always_flush::Bool
 end
 
@@ -39,10 +39,10 @@ function handle_message(logger::FormatLogger, args...; kwargs...)
     # We help the user by passing an IOBuffer to the formatting function
     # to make sure that everything writes to the logger io in one go.
     iob = IOBuffer()
-    ioc = IOContext(iob, logger.io)
+    ioc = IOContext(iob, logger.stream)
     logger.f(ioc, log_args)
-    write(logger.io, take!(iob))
-    logger.always_flush && flush(logger.io)
+    write(logger.stream, take!(iob))
+    logger.always_flush && flush(logger.stream)
     return nothing
 end
 shouldlog(logger::FormatLogger, arg...) = true


### PR DESCRIPTION
This makes it possible to control the formatting of the `DatetimeRotatingLogger` sink.

---

My first draft made it possible to pass any logger to the constructor. However, that does not generalize well since the `DatetimeRotatingLogger` need to reconstruct the logger with a new IO. It is also not necessary since this is meant as a sink. It is just nice to have the option to control the format.

By supporting `SimpleLogger` and `FormatLogger` you have everything you need here: if you don't care about the formatting `SimpleLogger` just takes the place of a default formatting function, and if you do care about it you can control it.