### PR TITLE
Implement a callback function for DatetimeRotatingFileLogger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ julia> filter(f -> endswith(f, ".log"), readdir(pwd()))
 ```
 
 The user implicitly controls when the files will be rolled over based on the `DateFormat` given.
+To post-process the newly rotated file pass `rotation_callback::Function` as a keyword argument.
+See the docstring with (`?DatetimeRotatingFileLogger` in the REPL) for more details.
+
 To control the logging output it is possible to pass a formatter function as the first argument
 in the constructor. See `FormatLogger` for the requirements on the formatter function.
 


### PR DESCRIPTION
This allows passing a callback that is called with the previous file whenever the logger rotates the backing file. Example callback to compress the logfile:
```julia
callback(nt) = run(`gzip $(nt.file)`)
```

