### PR TITLE
 Support function-like objects in `FormatLogger`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoggingExtras"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 authors = ["Frames White <oxinabox@ucc.asn.au>", "Collaborators <https://github.com/JuliaLogging/LoggingExtras.jl/graphs/contributors>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Sinks/datetime_rotation.jl
+++ b/src/Sinks/datetime_rotation.jl
@@ -71,7 +71,7 @@ function DatetimeRotatingFileLogger(f::Union{Function,Nothing}, dir, filename_pa
 end
 
 similar_logger(::SimpleLogger, io) = SimpleLogger(io, BelowMinLevel)
-similar_logger(l::FormatLogger, io) = FormatLogger(l.f, io, l.always_flush)
+similar_logger(l::FormatLogger, io) = FormatLogger(l.formatter, io, l.always_flush)
 function reopen!(drfl::DatetimeRotatingFileLogger)
     if drfl.current_file !== nothing
         # close the old IOStream and pass the file to the callback

--- a/src/Sinks/formatlogger.jl
+++ b/src/Sinks/formatlogger.jl
@@ -9,8 +9,8 @@ end
     FormatLogger(formatter, io::IO=stderr; always_flush=true)
 
 Logger sink that formats the message and finally writes to `io`.
-The formatting function should be of the form `formatter(io::IOContext, log_args::NamedTuple)`
-where `log_args` has the following fields:
+The formatting function should be of the form `formatter(io::IOContext, log::NamedTuple)`
+where `log` has the following fields:
 `(level, message, _module, group, id, file, line, kwargs)`.
 See [`LoggingExtras.handle_message_args`](@ref) for more information on what field is.
 
@@ -18,8 +18,8 @@ See [`LoggingExtras.handle_message_args`](@ref) for more information on what fie
 ```julia-repl
 julia> using Logging, LoggingExtras
 
-julia> logger = FormatLogger() do io, args
-           println(io, args._module, " | ", "[", args.level, "] ", args.message)
+julia> logger = FormatLogger() do io, log
+           println(io, log._module, " | ", "[", log.level, "] ", log.message)
        end;
 
 julia> with_logger(logger) do
@@ -49,12 +49,12 @@ function FormatLogger(formatter, path::AbstractString; append::Bool=false, kw...
 end
 
 function handle_message(logger::FormatLogger, args...; kwargs...)
-    log_args = handle_message_args(args...; kwargs...)
+    log = handle_message_args(args...; kwargs...)
     # We help the user by passing an IOBuffer to the formatting function
     # to make sure that everything writes to the logger io in one go.
     iob = IOBuffer()
     ioc = IOContext(iob, logger.stream)
-    logger.formatter(ioc, log_args)
+    logger.formatter(ioc, log)
     write(logger.stream, take!(iob))
     logger.always_flush && flush(logger.stream)
     return nothing

--- a/src/Sinks/formatlogger.jl
+++ b/src/Sinks/formatlogger.jl
@@ -8,10 +8,11 @@ end
     FormatLogger(formatter, io::IO=stderr; always_flush=true)
 
 Logger sink that formats the message and finally writes to `io`.
-The formatting function should be of the form `formatter(io::IOContext, log::NamedTuple)`
-where `log` has the following fields:
+The formatting function or callable object should be of the form
+`formatter(io::IOContext, log::NamedTuple)` where `log` has the following fields:
 `(level, message, _module, group, id, file, line, kwargs)`.
-See [`LoggingExtras.handle_message_args`](@ref) for more information on what field is.
+
+See [`LoggingExtras.handle_message_args`](@ref) for more information on what each field is.
 
 # Examples
 ```julia-repl
@@ -36,8 +37,8 @@ end
 """
     FormatLogger(formatter, path::AbstractString; append=false, always_flush=true)
 
-Logger sink that formats the message and writes it to the file at `path`.  This is similar
-to `FileLogger` except that it allows specifying the printing format.
+Logger sink that formats the message and writes it to the file at `path`. This is similar
+to [`FileLogger`](@ref) except that it allows specifying the printing format.
 
 To append to the file (rather than truncating the file first), use `append=true`.
 If `always_flush=true` the stream is flushed after every handled log message.

--- a/src/Sinks/formatlogger.jl
+++ b/src/Sinks/formatlogger.jl
@@ -1,15 +1,15 @@
 
 struct FormatLogger <: AbstractLogger
-    f::Function
+    formatter
     stream::IO
     always_flush::Bool
 end
 
 """
-    FormatLogger(f::Function, io::IO=stderr; always_flush=true)
+    FormatLogger(formatter, io::IO=stderr; always_flush=true)
 
 Logger sink that formats the message and finally writes to `io`.
-The formatting function should be of the form `f(io::IOContext, log_args::NamedTuple)`
+The formatting function should be of the form `formatter(io::IOContext, log_args::NamedTuple)`
 where `log_args` has the following fields:
 `(level, message, _module, group, id, file, line, kwargs)`.
 See [`LoggingExtras.handle_message_args`](@ref) for more information on what field is.
@@ -30,12 +30,12 @@ Main | [Info] This is an informational message.
 Main | [Warn] This is a warning, should take a look.
 ```
 """
-function FormatLogger(f::Function, io::IO=stderr; always_flush=true)
-    return FormatLogger(f, io, always_flush)
+function FormatLogger(formatter, io::IO=stderr; always_flush=true)
+    return FormatLogger(formatter, io, always_flush)
 end
 
 """
-    FormatLogger(f::Function, path::AbstractString; append=false, always_flush=true)
+    FormatLogger(formatter, path::AbstractString; append=false, always_flush=true)
 
 Logger sink that formats the message and writes it to the file at `path`.  This is similar
 to `FileLogger` except that it allows specifying the printing format.
@@ -43,9 +43,9 @@ to `FileLogger` except that it allows specifying the printing format.
 To append to the file (rather than truncating the file first), use `append=true`.
 If `always_flush=true` the stream is flushed after every handled log message.
 """
-function FormatLogger(f::Function, path::AbstractString; append::Bool=false, kw...)
+function FormatLogger(formatter, path::AbstractString; append::Bool=false, kw...)
     io = open(path, append ? "a" : "w")
-    return FormatLogger(f, io; kw...)
+    return FormatLogger(formatter, io; kw...)
 end
 
 function handle_message(logger::FormatLogger, args...; kwargs...)
@@ -54,7 +54,7 @@ function handle_message(logger::FormatLogger, args...; kwargs...)
     # to make sure that everything writes to the logger io in one go.
     iob = IOBuffer()
     ioc = IOContext(iob, logger.stream)
-    logger.f(ioc, log_args)
+    logger.formatter(ioc, log_args)
     write(logger.stream, take!(iob))
     logger.always_flush && flush(logger.stream)
     return nothing
@@ -62,3 +62,12 @@ end
 shouldlog(logger::FormatLogger, arg...) = true
 min_enabled_level(logger::FormatLogger) = BelowMinLevel
 catch_exceptions(logger::FormatLogger) = true # Or false? SimpleLogger doesn't, ConsoleLogger does.
+
+# For backwards compatibility
+function Base.getproperty(logger::FormatLogger, f::Symbol)
+    return if f === :f
+        getfield(logger, :formatter)
+    else
+        getfield(logger, f)
+    end
+end

--- a/src/Sinks/formatlogger.jl
+++ b/src/Sinks/formatlogger.jl
@@ -1,6 +1,5 @@
-
-struct FormatLogger <: AbstractLogger
-    formatter
+struct FormatLogger{T} <: AbstractLogger
+    formatter::T
     stream::IO
     always_flush::Bool
 end

--- a/src/Sinks/formatlogger.jl
+++ b/src/Sinks/formatlogger.jl
@@ -62,12 +62,3 @@ end
 shouldlog(logger::FormatLogger, arg...) = true
 min_enabled_level(logger::FormatLogger) = BelowMinLevel
 catch_exceptions(logger::FormatLogger) = true # Or false? SimpleLogger doesn't, ConsoleLogger does.
-
-# For backwards compatibility
-function Base.getproperty(logger::FormatLogger, f::Symbol)
-    return if f === :f
-        getfield(logger, :formatter)
-    else
-        getfield(logger, f)
-    end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,23 +201,23 @@ Base.@kwdef struct BasicLogFormatter
     include_module::Bool=true
 end
 
-function (formatter::BasicLogFormatter)(io::IO, args::NamedTuple)
+function (formatter::BasicLogFormatter)(io::IO, log::NamedTuple)
     if formatter.include_module
-        print(io, args._module, " | ")
+        print(io, log._module, " | ")
     end
-    println(io, "[", args.level, "] ", args.message)
+    println(io, "[", log.level, "] ", log.message)
 end
 
 @testset "FormatLogger" begin
     io = IOBuffer()
-    logger = FormatLogger(io) do io, args
+    logger = FormatLogger(io) do io, log
         # Put in some bogus sleep calls just to test that
         # log records writes in one go
-        print(io, args.level)
+        print(io, log.level)
         sleep(rand())
         print(io, ": ")
         sleep(rand())
-        println(io, args.message)
+        println(io, log.message)
     end
     with_logger(logger) do
         @sync begin
@@ -242,7 +242,7 @@ end
     mktempdir() do dir
         f = joinpath(dir, "test.log")
 
-        logger = FormatLogger(f) do io, args
+        logger = FormatLogger(f) do io, log
             println(io, "log message")
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,7 +197,7 @@ end
     end
 end
 
-# NOTE: this intentionally does not subtype Function
+# Intentionally not subtype `Function` here to test function-like object support
 Base.@kwdef struct BasicLogFormatter
     include_module::Bool=true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,7 @@ end
     end
 end
 
+# NOTE: this intentionally does not subtype Function
 Base.@kwdef struct BasicLogFormatter
     include_module::Bool=true
 end


### PR DESCRIPTION
Allows for custom log formatters to be created from types without having to declare it a subtype of `Function`.